### PR TITLE
Add dependency on MySQL DB instance for FW/authorized network rules

### DIFF
--- a/terraform/azure-mysql/provision-mysql.tf
+++ b/terraform/azure-mysql/provision-mysql.tf
@@ -130,6 +130,7 @@ resource "azurerm_mysql_virtual_network_rule" "allow_subnet_id" {
   server_name         = azurerm_mysql_server.instance.name
   subnet_id           = var.authorized_network
   count = var.authorized_network != "default" ? 1 : 0
+  depends_on = [azurerm_mysql_database.instance-db]
 }
 
 resource "azurerm_mysql_virtual_network_rule" "allow_subnet_ids" {
@@ -138,6 +139,7 @@ resource "azurerm_mysql_virtual_network_rule" "allow_subnet_ids" {
   server_name         = azurerm_mysql_server.instance.name
   subnet_id           = var.authorized_networks[count.index]
   count = length(var.authorized_networks)
+  depends_on = [azurerm_mysql_database.instance-db]
 }
 
 resource "azurerm_mysql_firewall_rule" "allow_azure" {
@@ -147,6 +149,7 @@ resource "azurerm_mysql_firewall_rule" "allow_azure" {
   start_ip_address    = "0.0.0.0"
   end_ip_address      = "0.0.0.0"
   count = var.authorized_network == "default" ? 1 : 0
+  depends_on = [azurerm_mysql_database.instance-db]
 }    
 
 resource "azurerm_mysql_firewall_rule" "allow_firewall" {
@@ -156,6 +159,7 @@ resource "azurerm_mysql_firewall_rule" "allow_firewall" {
   start_ip_address    = var.firewall_rules[count.index][0]
   end_ip_address      = var.firewall_rules[count.index][1]
   count = length(var.firewall_rules)
+  depends_on = [azurerm_mysql_database.instance-db]
 }    
 
 output name { value = azurerm_mysql_database.instance-db.name }


### PR DESCRIPTION
I have found that MySQL instance creation fails intermittently when authorized_networks is configured and after playing around with changes adding a dependency such the DB itself is created before the FW and authorized networks rules are created seems to resolve this.