### PR TITLE
Private Endpoint support for Redis and MySQL

### DIFF
--- a/azure-mysql.yml
+++ b/azure-mysql.yml
@@ -77,6 +77,15 @@ provision:
     - field_name: firewall_rules
       type: array
       details: Array of firewall rule start/end IP pairs (e.g. [["1.2.3.4", "2.3.4.5"], ["5.6.7.8", "6.7.8.9"]])
+      default: []
+    - field_name: private_endpoint_subnet_id
+      type: string
+      details: The ID of the Subnet within which Private Endpoint for the Redis cache will be created.
+      default: ""
+    - field_name: private_dns_zone_ids
+      type: array
+      details: Array of Private DNS Zone IDs to create private DNS zone groups for when using Private Endpoints
+      default: []
   user_inputs:
     - field_name: cores
       type: integer

--- a/azure-redis.yml
+++ b/azure-redis.yml
@@ -125,6 +125,15 @@ provision:
   - field_name: firewall_rules
     type: array
     details: Array of firewall rule start/end IP pairs (e.g. [["1.2.3.4", "2.3.4.5"], ["5.6.7.8", "6.7.8.9"]])
+    default: []
+  - field_name: private_endpoint_subnet_id
+    type: string
+    details: The ID of the Subnet within which Private Endpoint for the Redis cache will be created.
+    default: ""
+  - field_name: private_dns_zone_ids
+    type: array
+    details: Array of Private DNS Zone IDs to create private DNS zone groups for when using Private Endpoints
+    default: []
   user_inputs:
   - field_name: instance_name
     type: string

--- a/terraform/azure-mysql/provision-mysql.tf
+++ b/terraform/azure-mysql/provision-mysql.tf
@@ -35,10 +35,7 @@ variable enable_threat_detection_policy { type = bool }
 variable threat_detection_policy_emails { type = list(string) }
 variable email_account_admins { type = bool }
 variable firewall_rules { type = list(list(string)) }
-variable private_endpoint_subnet_id { 
-  type = string 
-  default = ""
-}
+variable private_endpoint_subnet_id { type = string }
 variable private_dns_zone_ids { type = list(string) }
 
 
@@ -67,7 +64,7 @@ locals {
   sku_name = length(var.sku_name) == 0 ? local.instance_types[var.cores] : var.sku_name    
   resource_group = length(var.resource_group) == 0 ? format("rg-%s", var.instance_name) : var.resource_group
   tls_version = var.use_tls == true ? var.tls_min_version : "TLSEnforcementDisabled"
-  private_endpoint_enabled = length(var.private_endpoint_subnet_id) > 0 ? true : false
+  private_endpoint_enabled = var.private_endpoint_subnet_id == null ? false : length(var.private_endpoint_subnet_id) > 0 ? true : false
 }
 
 resource "azurerm_resource_group" "azure-msyql" {

--- a/terraform/azure-mysql/provision-mysql.tf
+++ b/terraform/azure-mysql/provision-mysql.tf
@@ -159,7 +159,7 @@ resource "azurerm_mysql_firewall_rule" "allow_azure" {
   server_name         = azurerm_mysql_server.instance.name
   start_ip_address    = "0.0.0.0"
   end_ip_address      = "0.0.0.0"
-  count = var.authorized_network == "default" ? 1 : 0
+  count = var.authorized_network == "default" && local.private_endpoint_enabled == false ? 1 : 0
   depends_on = [azurerm_mysql_database.instance-db]
 }    
 

--- a/terraform/azure-mysql/provision-mysql.tf
+++ b/terraform/azure-mysql/provision-mysql.tf
@@ -35,7 +35,10 @@ variable enable_threat_detection_policy { type = bool }
 variable threat_detection_policy_emails { type = list(string) }
 variable email_account_admins { type = bool }
 variable firewall_rules { type = list(list(string)) }
-variable private_endpoint_subnet_id { type = string }
+variable private_endpoint_subnet_id { 
+  type = string 
+  default = ""
+}
 variable private_dns_zone_ids { type = list(string) }
 
 
@@ -64,7 +67,7 @@ locals {
   sku_name = length(var.sku_name) == 0 ? local.instance_types[var.cores] : var.sku_name    
   resource_group = length(var.resource_group) == 0 ? format("rg-%s", var.instance_name) : var.resource_group
   tls_version = var.use_tls == true ? var.tls_min_version : "TLSEnforcementDisabled"
-  private_endpoint_enabled = var.private_endpoint_subnet_id == null || length(var.private_endpoint_subnet_id) > 0 ? true : false
+  private_endpoint_enabled = length(var.private_endpoint_subnet_id) > 0 ? true : false
 }
 
 resource "azurerm_resource_group" "azure-msyql" {

--- a/terraform/azure-mysql/provision-mysql.tf
+++ b/terraform/azure-mysql/provision-mysql.tf
@@ -113,6 +113,7 @@ resource "azurerm_mysql_server" "instance" {
   ssl_minimal_tls_version_enforced = local.tls_version
   backup_retention_days            = var.backup_retention_days
   auto_grow_enabled = true
+  public_network_access_enabled = local.private_endpoint_enabled ? false : true
 
   dynamic "threat_detection_policy" {
     for_each = var.enable_threat_detection_policy == null ? [] : (var.enable_threat_detection_policy ? [1] : [])

--- a/terraform/azure-mysql/provision-mysql.tf
+++ b/terraform/azure-mysql/provision-mysql.tf
@@ -64,7 +64,7 @@ locals {
   sku_name = length(var.sku_name) == 0 ? local.instance_types[var.cores] : var.sku_name    
   resource_group = length(var.resource_group) == 0 ? format("rg-%s", var.instance_name) : var.resource_group
   tls_version = var.use_tls == true ? var.tls_min_version : "TLSEnforcementDisabled"
-  private_endpoint_enabled = length(var.private_endpoint_subnet_id) > 0 ? true : false
+  private_endpoint_enabled = var.private_endpoint_subnet_id == null || length(var.private_endpoint_subnet_id) > 0 ? true : false
 }
 
 resource "azurerm_resource_group" "azure-msyql" {

--- a/terraform/azure-redis/redis-provision.tf
+++ b/terraform/azure-redis/redis-provision.tf
@@ -28,7 +28,10 @@ variable tls_min_version { type = string }
 variable maxmemory_policy { type = string }
 variable firewall_rules { type = list(list(string)) }
 variable subnet_id { type = string }
-variable private_endpoint_subnet_id { type = string }
+variable private_endpoint_subnet_id { 
+  type = string 
+  default = ""
+}
 variable private_dns_zone_ids { type = list(string) }
 
 provider "azurerm" {
@@ -51,7 +54,7 @@ resource "random_string" "random" {
 
 locals {
   resource_group = length(var.resource_group) == 0 ? format("rg-%s", var.instance_name) : var.resource_group
-  private_endpoint_enabled = var.private_endpoint_subnet_id == null || length(var.private_endpoint_subnet_id) > 0 ? true : false
+  private_endpoint_enabled = length(var.private_endpoint_subnet_id) > 0 ? true : false
 }
 
 resource "azurerm_resource_group" "azure-redis" {

--- a/terraform/azure-redis/redis-provision.tf
+++ b/terraform/azure-redis/redis-provision.tf
@@ -28,10 +28,7 @@ variable tls_min_version { type = string }
 variable maxmemory_policy { type = string }
 variable firewall_rules { type = list(list(string)) }
 variable subnet_id { type = string }
-variable private_endpoint_subnet_id { 
-  type = string 
-  default = ""
-}
+variable private_endpoint_subnet_id { type = string }
 variable private_dns_zone_ids { type = list(string) }
 
 provider "azurerm" {
@@ -54,7 +51,7 @@ resource "random_string" "random" {
 
 locals {
   resource_group = length(var.resource_group) == 0 ? format("rg-%s", var.instance_name) : var.resource_group
-  private_endpoint_enabled = length(var.private_endpoint_subnet_id) > 0 ? true : false
+  private_endpoint_enabled = var.private_endpoint_subnet_id == null ? false : length(var.private_endpoint_subnet_id) > 0 ? true : false
 }
 
 resource "azurerm_resource_group" "azure-redis" {

--- a/terraform/azure-redis/redis-provision.tf
+++ b/terraform/azure-redis/redis-provision.tf
@@ -70,6 +70,7 @@ resource "azurerm_redis_cache" "redis" {
   location            = var.location
   resource_group_name = local.resource_group
   minimum_tls_version = length(var.tls_min_version) == 0 ? "1.2" : var.tls_min_version
+  public_network_access_enabled = local.private_endpoint_enabled ? false : true
   tags                = var.labels
   redis_configuration {
     maxmemory_policy   = length(var.maxmemory_policy) == 0 ? "allkeys-lru" : var.maxmemory_policy

--- a/terraform/azure-redis/redis-provision.tf
+++ b/terraform/azure-redis/redis-provision.tf
@@ -51,7 +51,7 @@ resource "random_string" "random" {
 
 locals {
   resource_group = length(var.resource_group) == 0 ? format("rg-%s", var.instance_name) : var.resource_group
-  private_endpoint_enabled = length(var.private_endpoint_subnet_id) > 0 ? true : false
+  private_endpoint_enabled = var.private_endpoint_subnet_id == null || length(var.private_endpoint_subnet_id) > 0 ? true : false
 }
 
 resource "azurerm_resource_group" "azure-redis" {


### PR DESCRIPTION
Adds new plan inputs `private_endpoint_subnet_id` and `private_dns_zone_ids` to support creating Private Endpoints during provisioning.