### PR TITLE
fix: remove duplicate plan ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 IAAS=azure
 DOCKER_OPTS=--rm -v $(PWD):/brokerpak -w /brokerpak --network=host
-CSB=cfplatformeng/csb
+CSB := $(or $(CSB), cfplatformeng/csb)
 
 .PHONY: build
 build: $(IAAS)-services-*.brokerpak 

--- a/acceptance-tests/azure/cf-test-spring-music-service.sh
+++ b/acceptance-tests/azure/cf-test-spring-music-service.sh
@@ -21,7 +21,12 @@ done
 
 UPDATE_SERVICES=("csb-azure-mysql" "csb-azure-mssql" "csb-azure-mssql-failover-group" "csb-azure-postgresql")
 for s in "${UPDATE_SERVICES[@]}"; do
-    create_service "${s}" small "${s}-$$" &
+    if [ "${s}" -eq "csb-azure-mssql-failover-group" ]; then
+        plan="small-v2"
+    else
+        plan="small"
+    fi
+    create_service "${s}" "$plan" "${s}-$$" &
     INSTANCES+=("${s}-$$")
     UPDATE_INSTANCES+=("${s}-$$")
 done

--- a/azure-mssql-failover.yml
+++ b/azure-mssql-failover.yml
@@ -23,8 +23,8 @@ support_url: https://docs.microsoft.com/en-us/azure/sql-database/sql-database-au
 tags: [azure, mssql, sqlserver, dr, failover, preview]
 plan_updateable: true
 plans:
-- name: small
-  id: a556d1b4-5825-11ea-adb8-00155d4dfe6c
+- name: small-v2
+  id: eb9856fa-b285-11eb-ae46-536679aeffe8
   description: 'SQL Server latest version. Instance properties: General Purpose - Serverless ; 0.5 - 2 cores ; Max Memory: 6gb ; 50 GB storage ; auto-pause enabled after 1 hour of inactivity'
   display_name: "Small"
   properties:
@@ -285,7 +285,7 @@ bind:
 examples:
 - name: failover-group-azuresql-db-small-configuration
   description: Create a small Azure SQL Database failover group 
-  plan_id: a556d1b4-5825-11ea-adb8-00155d4dfe6c
+  plan_id: eb9856fa-b285-11eb-ae46-536679aeffe8
   provision_params: {}
   bind_params: {}
   bind_can_fail: true  


### PR DESCRIPTION
Since https://github.com/cloudfoundry/cloud_controller_ng/commit/8a4926db17807b2cad1736614784f0c57ba49336,
Cloud Foundry will fail if a broker uses duplicate IDs for plans as they should be universally unique.
Because some users will be upgrading from earlier versions of Cloud
Foundry we have changed the duplicate plan ID and name. This means that
users will have to update exisitng "small" services to be "small-v2"
after upgrading. But by changing both the name and the ID we avoid
an error occuring where the same name is associated with more than one
ID.

[#177727007](https://www.pivotaltracker.com/story/show/177727007)