### PR TITLE
Update Terraform for new provider version

### DIFF
--- a/terraform/azure-mongodb/azure-mongodb.tf
+++ b/terraform/azure-mongodb/azure-mongodb.tf
@@ -115,6 +115,11 @@ resource "azurerm_cosmosdb_mongo_collection" "mongo-collection" {
 
 	default_ttl_seconds = "777"
 	shard_key           = var.shard_key
+
+	index {
+		keys = [var.shard_key]
+		unique = true
+	}
 }
 
 output uri { value = replace(azurerm_cosmosdb_account.mongo-account.connection_strings[0], "/?", "/${azurerm_cosmosdb_mongo_database.mongo-db.name}?")  }

--- a/terraform/azure-mssql-db-failover/mssql-db-fog-main.tf
+++ b/terraform/azure-mssql-db-failover/mssql-db-fog-main.tf
@@ -28,7 +28,6 @@ resource "azurerm_mssql_database" "secondary_db" {
   name                = var.db_name
   server_id           = data.azurerm_sql_server.secondary_sql_db_server.id
   sku_name            = local.sku_name
-  max_size_gb         = var.max_storage_gb
   tags                = var.labels  
   create_mode         = "Secondary"
   creation_source_database_id = azurerm_mssql_database.primary_db[0].id

--- a/terraform/azure-mssql-failover/provision-mssql-failover.tf
+++ b/terraform/azure-mssql-failover/provision-mssql-failover.tf
@@ -155,7 +155,6 @@ resource "azurerm_mssql_database" "secondary_azure_sql_db" {
   sku_name            = local.sku_name
   tags                = var.labels
   create_mode         = "Secondary"
-  max_size_gb         = var.max_storage_gb
   creation_source_database_id  = azurerm_mssql_database.azure_sql_db.id
 }
 


### PR DESCRIPTION
Following on from cd7c9f7 there need to be some updates to the Terraform
in order to be compliant with the new provider version:
- secondary DBs cannot have the size set as this is computed from the
primary
- Cosmos Mongo needs the shard index to also be defined as a unique
index

Also updated the Makefile to add some user help

[#178142486](https://www.pivotaltracker.com/story/show/178142486)