### PR TITLE
fix: remove duplicate plan ID (part 2)

### DIFF
--- a/acceptance-tests/azure/cf-test-spring-music-service.sh
+++ b/acceptance-tests/azure/cf-test-spring-music-service.sh
@@ -24,6 +24,8 @@ UPDATE_SERVICES=("csb-azure-mysql" "csb-azure-mssql" "csb-azure-mssql-failover-g
 for s in "${UPDATE_SERVICES[@]}"; do
     if [ "${s}" == "csb-azure-mssql-failover-group" ]; then
         plan="small-v2"
+    elif [ "${s}" == "csb-azure-mssql" ]; then
+        plan="small-v2"
     else
         plan="small"
     fi

--- a/azure-mssql.yml
+++ b/azure-mssql.yml
@@ -23,8 +23,8 @@ support_url: https://docs.microsoft.com/en-us/azure/sql-database/
 tags: [azure, mssql, sqlserver, preview]
 plan_updateable: true
 plans:
-- name: small
-  id: a556d1b4-5825-11ea-adb8-00155d4dfe6c
+- name: small-v2
+  id: 99ed044a-bf9b-11eb-a49a-e347783607d6
   description: 'SQL Server latest version. Instance properties: General Purpose - Serverless ; 0.5 - 2 cores ; Max Memory: 6gb ; 50 GB storage ; auto-pause enabled after 1 hour of inactivity'
   display_name: "Small"
   properties:
@@ -238,7 +238,7 @@ bind:
 examples:
 - name: azuresql-db-small-configuration
   description: Create a small Azure SQL Database in westcentralus location
-  plan_id: a556d1b4-5825-11ea-adb8-00155d4dfe6c
+  plan_id: 99ed044a-bf9b-11eb-a49a-e347783607d6
   provision_params: {"location": "eastus"}
   bind_params: {}
   bind_can_fail: true  


### PR DESCRIPTION
Previous fix #34 was sufficient to allow the brokerpak to install on a
fresh TAS 2.11 system, but upgrades from previous versions of Cloud Foundry
failed because there was still a reference to the duplicated ID in the
Cloud Foundry database. By removing all references to
`a556d1b4-5825-11ea-adb8-00155d4dfe6c`, we make sure that this error
cannot occur, although it does mean that service instances of two plans
will need to be updated to the *-v2 version of the plan.

[#178330774](https://www.pivotaltracker.com/story/show/178330774)