### PR TITLE
test: tests should work on CF 8, and earlier

### DIFF
--- a/acceptance-tests/helpers/cf_version.go
+++ b/acceptance-tests/helpers/cf_version.go
@@ -1,0 +1,28 @@
+package helpers
+
+import (
+	"strings"
+)
+
+type cfVersionType int
+
+const (
+	cfVersionUnknown cfVersionType = iota
+	cfVersionLegacy
+	cfVersionV8
+)
+
+var cachedCFVersion cfVersionType
+
+func cfVersion() cfVersionType {
+	if cachedCFVersion == cfVersionUnknown {
+		out, _ := CF("version")
+		switch {
+		case strings.HasPrefix(out, "cf version 8"):
+			cachedCFVersion = cfVersionV8
+		default:
+			cachedCFVersion = cfVersionLegacy
+		}
+	}
+	return cachedCFVersion
+}


### PR DESCRIPTION
CF CLI v8 will introduce some useful changes for services, specifically
the --wait flag for creating and deleting service instances. It also
introduces some incidental features such as a subtle difference in
output for the "cf service-key" command. This change allows the tests to
run with CF 8 and use the --wait flag, or to run on earlier versions and
still work