### PR TITLE
fix: binding DB user should also be in replica

### DIFF
--- a/terraform/azure-mssql/bind-mssql.tf
+++ b/terraform/azure-mssql/bind-mssql.tf
@@ -34,6 +34,9 @@ resource "random_password" "password" {
 }
 
 resource "null_resource" "create-sql-login" {
+  # we now create users instead of logins (see tracker story #179168006). We still want
+  # to remove logins created with older versions when we unbind. We ignore failures
+  # as current version does not create logins and so this would fail.
   provisioner "local-exec" {
 	  when = destroy
     command = format("psqlcmd %s %d %s master \"DROP LOGIN [%s]\"",

--- a/terraform/azure-mssql/bind-mssql.tf
+++ b/terraform/azure-mssql/bind-mssql.tf
@@ -33,43 +33,15 @@ resource "random_password" "password" {
   depends_on = [random_string.username]
 }
 
-resource "null_resource" "create-sql-login" {
-
-  provisioner "local-exec" {
-    command = format("psqlcmd %s %d %s master \"CREATE LOGIN [%s] with PASSWORD='%s'\"",
-                     var.mssql_hostname,
-                     var.mssql_port,
-                     var.admin_username,
-                     random_string.username.result,
-                     random_password.password.result)
-    environment = {
-      MSSQL_PASSWORD = var.admin_password
-    }
-  }
-
-  provisioner "local-exec" {
-	when = destroy
-    command = format("psqlcmd %s %d %s master \"DROP LOGIN [%s]\"",
-                     var.mssql_hostname,
-                     var.mssql_port,
-                     var.admin_username,
-                     random_string.username.result)
-    environment = {
-      MSSQL_PASSWORD = var.admin_password
-    }
-  }
-  depends_on = [random_password.password]
-}
-
 resource "null_resource" "create-sql-user" {
   provisioner "local-exec" {
-    command = format("psqlcmd %s %d %s %s \"CREATE USER [%s] from LOGIN %s;\"",
+    command = format("psqlcmd %s %d %s %s \"CREATE USER [%s] with PASSWORD='%s';\"",
                      var.mssql_hostname,
                      var.mssql_port,
                      var.admin_username,
                      var.mssql_db_name,
                      random_string.username.result,
-                     random_string.username.result)
+                     random_password.password.result)
     environment = {
       MSSQL_PASSWORD = var.admin_password
     }
@@ -88,7 +60,7 @@ resource "null_resource" "create-sql-user" {
     }
   }
 
-  depends_on = [null_resource.create-sql-login]
+  depends_on = [random_password.password]
 }
 
 locals {


### PR DESCRIPTION
This relates to the `csb-azure-mssql-failover-group` service offering.
By creating the user in the `master` database on the primary, it seems
that the user was not propagated to the secondary. The fix is
copied from the csb-azure-mssql-db-failover-group service and results in
the user appearing in both the primary and secondary databases.

[#179168006](https://www.pivotaltracker.com/story/show/179168006)