### PR TITLE
test: update examples to no longer use MySQL 5.6

### DIFF
--- a/azure-mysql.yml
+++ b/azure-mysql.yml
@@ -290,10 +290,10 @@ examples:
     provision_params: { "use_tls": false }
     bind_params: {}
     bind_can_fail: true
-  - name: small-v5.6-50gb-storage
-    description: Create a small mysql v5.6 instance with 50gb storage
+  - name: small-v8.0-50gb-storage
+    description: Create a small mysql v8.0 instance with 50gb storage
     plan_id: 828e324e-6b34-4f50-b224-9b956dd2d1b7
-    provision_params: { "mysql_version": "5.6", "storage_gb": 50 }
+    provision_params: { "mysql_version": "8.0", "storage_gb": 50 }
     bind_params: {}
     bind_can_fail: true
   - name: medium


### PR DESCRIPTION
When we try to create a MySQL 5.6 database we get:
```
Code="InvalidVersion" Message="Version '5.6' is not supported."
```

So we should update the examples test. It's probably just testing a
non-default version, so updated to test v8. Decided not to remove v5.6
from the allowed version enum because this might cause issues for people
who already have a v5.6 DB and are doing an update-service.

[#179433132](https://www.pivotaltracker.com/story/show/179433132)