### PR TITLE
fix: PostgreSQL user needs permissions to create schema

### DIFF
--- a/acceptance-tests/apps/postgresqlapp/internal/app/app.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 
 	"github.com/gorilla/mux"
 	_ "github.com/jackc/pgx/v4/stdlib"
@@ -20,9 +21,11 @@ func App(uri string) *mux.Router {
 	db := connect(uri)
 
 	r := mux.NewRouter()
-	r.HandleFunc("/", aliveness).Methods("HEAD", "GET")
-	r.HandleFunc("/{key}", handleSet(db)).Methods("PUT")
-	r.HandleFunc("/{key}", handleGet(db)).Methods("GET")
+	r.HandleFunc("/", aliveness).Methods(http.MethodHead, http.MethodGet)
+	r.HandleFunc("/{schema}", handleCreateSchema(db)).Methods(http.MethodPut)
+	r.HandleFunc("/{schema}", handleDropSchema(db)).Methods(http.MethodDelete)
+	r.HandleFunc("/{schema}/{key}", handleSet(db)).Methods(http.MethodPut)
+	r.HandleFunc("/{schema}/{key}", handleGet(db)).Methods(http.MethodGet)
 
 	return r
 }
@@ -38,10 +41,28 @@ func connect(uri string) *sql.DB {
 		log.Fatalf("failed to connect to database: %s", err)
 	}
 
-	_, err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (%s VARCHAR(255) NOT NULL, %s VARCHAR(255) NOT NULL)`, tableName, keyColumn, valueColumn))
-	if err != nil {
-		log.Fatalf("failed to create test table: %s", err)
-	}
-
 	return db
+}
+
+func schemaName(r *http.Request) (string, error) {
+	schema, ok := mux.Vars(r)["schema"]
+
+	switch {
+	case !ok:
+		return "", fmt.Errorf("schema missing")
+	case len(schema) > 50:
+		return "", fmt.Errorf("schema name too long")
+	case len(schema) == 0:
+		return "", fmt.Errorf("schema name cannot be zero length")
+	case !regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString(schema):
+		return "", fmt.Errorf("schema name contains invalid characters")
+	default:
+		return schema, nil
+	}
+}
+
+func fail(w http.ResponseWriter, code int, format string, a ...interface{}) {
+	msg := fmt.Sprintf(format, a...)
+	log.Println(msg)
+	http.Error(w, msg, code)
 }

--- a/acceptance-tests/apps/postgresqlapp/internal/app/create_schema.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/create_schema.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func handleCreateSchema(db *sql.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Handling create schema.")
+
+		schema, err := schemaName(r)
+		if err != nil {
+			fail(w, http.StatusInternalServerError, "Schema name error: %s", err)
+			return
+		}
+
+		_, err = db.Exec(fmt.Sprintf(`CREATE SCHEMA %s`, schema))
+		if err != nil {
+			fail(w, http.StatusBadRequest, "Error creating schema: %s", err)
+			return
+		}
+
+		_, err = db.Exec(fmt.Sprintf(`GRANT ALL ON SCHEMA %s TO PUBLIC`, schema))
+		if err != nil {
+			fail(w, http.StatusBadRequest, "Error granting schema permissions: %s", err)
+			return
+		}
+
+		_, err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.%s (%s VARCHAR(255) NOT NULL, %s VARCHAR(255) NOT NULL)`, schema, tableName, keyColumn, valueColumn))
+		if err != nil {
+			fail(w, http.StatusBadRequest, "Error creating table: %s", err)
+			return
+		}
+
+		_, err = db.Exec(fmt.Sprintf(`GRANT ALL ON TABLE %s.%s TO PUBLIC`, schema, tableName))
+		if err != nil {
+			fail(w, http.StatusBadRequest, "Error granting table permissions: %s", err)
+			return
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		log.Printf("Schema %q created", schema)
+	}
+}

--- a/acceptance-tests/apps/postgresqlapp/internal/app/drop_schema.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/drop_schema.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func handleDropSchema(db *sql.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Handling drop schema.")
+
+		schema, err := schemaName(r)
+		if err != nil {
+			fail(w, http.StatusInternalServerError, "Schema name error: %s\n", err)
+			return
+		}
+
+		_, err = db.Exec(fmt.Sprintf(`DROP TABLE %s.%s`, schema, tableName))
+		if err != nil {
+			fail(w, http.StatusBadRequest, "Error dropping table: %s", err)
+			return
+		}
+
+		_, err = db.Exec(fmt.Sprintf(`DROP SCHEMA %s`, schema))
+		if err != nil {
+			fail(w, http.StatusBadRequest, "Error creating schema: %s", err)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+		log.Printf("Schema %q dropped", schema)
+	}
+}

--- a/acceptance-tests/apps/postgresqlapp/internal/app/set.go
+++ b/acceptance-tests/apps/postgresqlapp/internal/app/set.go
@@ -14,32 +14,34 @@ func handleSet(db *sql.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Println("Handling set.")
 
+		schema, err := schemaName(r)
+		if err != nil {
+			fail(w, http.StatusInternalServerError, "Schema name error: %s", err)
+			return
+		}
+
 		key, ok := mux.Vars(r)["key"]
 		if !ok {
-			log.Println("Key missing.")
-			http.Error(w, "Key missing.", http.StatusBadRequest)
+			fail(w, http.StatusBadRequest, "Key missing.")
 			return
 		}
 
 		rawValue, err := io.ReadAll(r.Body)
 		if err != nil {
-			log.Printf("Error parsing value: %s", err)
-			http.Error(w, "Failed to parse value.", http.StatusBadRequest)
+			fail(w, http.StatusBadRequest, "Error parsing value: %s", err)
 			return
 		}
 
-		stmt, err := db.Prepare(fmt.Sprintf(`INSERT INTO %s (%s, %s) VALUES ($1, $2)`, tableName, keyColumn, valueColumn))
+		stmt, err := db.Prepare(fmt.Sprintf(`INSERT INTO %s.%s (%s, %s) VALUES ($1, $2)`, schema, tableName, keyColumn, valueColumn))
 		if err != nil {
-			log.Printf("Error preparing statement: %s", err)
-			http.Error(w, "Failed to prepare statement.", http.StatusInternalServerError)
+			fail(w, http.StatusInternalServerError, "Error preparing statement: %s", err)
 			return
 		}
 		defer stmt.Close()
 
 		_, err = stmt.Exec(key, string(rawValue))
 		if err != nil {
-			log.Printf("Error inserting values: %s", err)
-			http.Error(w, "Failed to insert values.", http.StatusBadRequest)
+			fail(w, http.StatusBadRequest, "Error inserting values: %s", err)
 			return
 		}
 

--- a/terraform/azure-postgres/postgresql-bind.tf
+++ b/terraform/azure-postgres/postgresql-bind.tf
@@ -55,6 +55,14 @@ resource "postgresql_grant" "all_access" {
   depends_on  = [ postgresql_role.new_user ]
   database    = var.db_name
   role        = random_string.username.result
+  object_type = "database"
+  privileges  = ["ALL"]
+}
+
+resource "postgresql_grant" "table_access" {
+  depends_on  = [ postgresql_role.new_user ]
+  database    = var.db_name
+  role        = postgresql_role.new_user.name
   schema      = "public"
   object_type = "table"
   privileges  = ["ALL"]
@@ -83,4 +91,4 @@ output jdbcUrl {
                   local.username, 
                   random_password.password.result,
                   var.use_tls) 
-}  
+}


### PR DESCRIPTION
By default each user (which corresponds to each binding) is provided
with a private schema and has no access to other schemas. This means
that if two apps connect to the same service instance they see different
data, and if an app is re-bound it sees different data. By giving the
user permissions to create a schema, apps can create schemas that other
bindings can see.

This is the same fix as done for AWS: https://github.com/cloudfoundry-incubator/csb-brokerpak-aws/commit/cb6b8caeb0601ab2b503d231d6639a5953b525b7

[#179125219](https://www.pivotaltracker.com/story/show/179125219)