### PR TITLE
Fix issues with mongodb update

### DIFF
--- a/acceptance-tests/helpers/apps/push.go
+++ b/acceptance-tests/helpers/apps/push.go
@@ -15,6 +15,7 @@ const pushWaitTime = 20 * time.Minute
 
 type config struct {
 	name      string
+	start     bool
 	buildpack string
 	memory    string
 	manifest  string
@@ -29,13 +30,17 @@ func Push(opts ...Option) App {
 	defaults := []Option{WithName(random.Name(random.WithPrefix("app")))}
 	WithOptions(append(defaults, opts...)...)(&c)
 
-	cmd := []string{"push", "--no-start"}
-	switch {
-	case c.buildpack != "":
+	cmd := []string{"push"}
+	if !c.start {
+		cmd = append(cmd, "--no-start")
+	}
+	if c.buildpack != "" {
 		cmd = append(cmd, "-b", c.buildpack)
-	case c.memory != "":
+	}
+	if c.memory != "" {
 		cmd = append(cmd, "-m", c.memory)
-	case c.manifest != "":
+	}
+	if c.manifest != "" {
 		cmd = append(cmd, "-f", c.manifest)
 	}
 
@@ -101,6 +106,12 @@ func WithVariable(key, value string) Option {
 			c.variables = make(map[string]string)
 		}
 		c.variables[key] = value
+	}
+}
+
+func WithStartedState() Option {
+	return func(c *config) {
+		c.start = true
 	}
 }
 

--- a/acceptance-tests/helpers/service.go
+++ b/acceptance-tests/helpers/service.go
@@ -131,7 +131,7 @@ func (s ServiceInstance) Delete() {
 	Eventually(func() string {
 		out, _ := cf.Run("services")
 		return out
-	}, 30*time.Minute, 30*time.Second).ShouldNot(ContainSubstring(s.name))
+	}, time.Hour, 30*time.Second).ShouldNot(ContainSubstring(s.name))
 }
 
 func (s ServiceInstance) Bind(app apps.App, parameters ...interface{}) Binding {

--- a/acceptance-tests/helpers/service_broker.go
+++ b/acceptance-tests/helpers/service_broker.go
@@ -94,7 +94,7 @@ func DefaultBroker() ServiceBroker {
 }
 
 func (b ServiceBroker) Update(brokerDir string) {
-	brokerApp := apps.Push(apps.WithName(b.Name), apps.WithDir(brokerDir))
+	brokerApp := apps.Push(apps.WithName(b.Name), apps.WithDir(brokerDir), apps.WithStartedState())
 
 	session := cf.Start("update-service-broker", b.Name, brokerUsername, brokerPassword, brokerApp.URL)
 	waitForBrokerOperation(session, b.Name)
@@ -132,6 +132,7 @@ func setEnvVars(app apps.App, extra ...apps.EnvVar) {
 		apps.EnvVar{Name: "DB_TLS", Value: "skip-verify"},
 		apps.EnvVar{Name: "ENCRYPTION_ENABLED", Value: true},
 		apps.EnvVar{Name: "ENCRYPTION_PASSWORDS", Value: `[{"password": {"secret":"superSecretP@SSw0Rd1234!"},"label":"first-encryption","primary":true}]`},
+		apps.EnvVar{Name: "BROKERPAK_UPDATES_ENABLED", Value: true},
 	)
 
 	envVars = append(envVars, extra...)

--- a/acceptance-tests/mongodb/mongodb_test.go
+++ b/acceptance-tests/mongodb/mongodb_test.go
@@ -16,7 +16,7 @@ var _ = Describe("MongoDB", func() {
 		By("creating a service instance")
 		databaseName := random.Name(random.WithPrefix("database"))
 		collectionName := random.Name(random.WithPrefix("collection"))
-		serviceInstance := helpers.CreateServiceFromBroker("csb-azure-mongodb", "small", helpers.DefaultBroker().Name, map[string]interface{}{
+		serviceInstance := helpers.CreateServiceFromBroker("csb-azure-mongodb", "medium", helpers.DefaultBroker().Name, map[string]interface{}{
 			"db_name":         databaseName,
 			"collection_name": collectionName,
 			"shard_key":       "_id",
@@ -53,6 +53,13 @@ var _ = Describe("MongoDB", func() {
 
 		By("getting the document using the second app")
 		got := appTwo.GET("%s/%s/%s", databaseName, collectionName, documentName)
+		Expect(got).To(Equal(documentData))
+
+		By("updating the instance plan")
+		serviceInstance.UpdateService("-p", "large")
+
+		By("checking previous data still accessible")
+		got = appTwo.GET("%s/%s/%s", databaseName, collectionName, documentData)
 		Expect(got).To(Equal(documentData))
 	})
 })

--- a/acceptance-tests/upgrade/README.md
+++ b/acceptance-tests/upgrade/README.md
@@ -1,0 +1,18 @@
+## Upgrade tests
+
+These tests perform the following flow:
+- Push version A of this brokerpak (with broker)
+- Create some resources
+- Push version B of this brokerpak (with broker)
+- Check that the resources are still accessible
+- Create some more resources
+
+Two flags may be specified to control the versions used:
+- `-releasedBuildDir` specifies a directory with a built brokerpak at version A
+- `-developmentBuildDir` specifies a directory with a built brokerpak at version B
+
+Note that when running Ginkgo, these flags should go after a `--` to distinguish
+them from Ginkgo flags, for example:
+```
+ginkgo -v -- -releasedBuildDir ... -developmentBuildDir ...
+```

--- a/acceptance-tests/upgrade/update_and_upgrade_cosmos_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_cosmos_test.go
@@ -84,6 +84,7 @@ var _ = Describe("UpgradeCosmosTest", func() {
 			documentDataTwo := random.Hexadecimal()
 			appOne.PUT(documentDataTwo, "%s/%s/%s", databaseName, collectionName, documentNameTwo)
 
+			By("getting the document using the second app")
 			got = appTwo.GET("%s/%s/%s", databaseName, collectionName, documentNameTwo)
 			Expect(got).To(Equal(documentDataTwo))
 		})

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_db_failover_test.go
@@ -20,7 +20,7 @@ var _ = Describe("UpgradeMssqlDBFailoverTest", func() {
 			serviceBroker := helpers.CreateBroker(
 				helpers.BrokerWithPrefix("csb-db-fo"),
 				helpers.BrokerFromDir(releasedBuildDir),
-				helpers.BrokerWithEnv(helpers.EnvVar{Name: "MSSQL_DB_FOG_SERVER_PAIR_CREDS", Value: serversConfig.ServerPairsConfig()}),
+				helpers.BrokerWithEnv(apps.EnvVar{Name: "MSSQL_DB_FOG_SERVER_PAIR_CREDS", Value: serversConfig.ServerPairsConfig()}),
 			)
 
 			defer serviceBroker.Delete()

--- a/terraform/azure-mongodb/azure-mongodb.tf
+++ b/terraform/azure-mongodb/azure-mongodb.tf
@@ -108,6 +108,10 @@ resource "azurerm_cosmosdb_account" "mongo-account" {
     capabilities {
         name = "EnableAggregationPipeline"
     }
+
+    capabilities {
+        name = "EnableMongo"
+    }
 }
 
 resource "azurerm_cosmosdb_mongo_database" "mongo-db" {
@@ -128,6 +132,11 @@ resource "azurerm_cosmosdb_mongo_collection" "mongo-collection" {
 
 	index {
 		keys = [var.shard_key]
+		unique = true
+	}
+
+	index {
+		keys = ["_id"]
 		unique = true
 	}
 }


### PR DESCRIPTION
- explicitely enable mongo API through capabilities. Without this there is an
account recreation on update
- add required _id index. Some context for this change in https://github.com/hashicorp/terraform-provider-azurerm/issues/8144#issuecomment-686955895

This PR doesn't have tests yet and therefore is draft. It was tested manually only.

[#180197227](https://www.pivotaltracker.com/story/show/180197227)