### PR TITLE
test: improve speed

### DIFF
--- a/acceptance-tests/mongodb/mongodb_test.go
+++ b/acceptance-tests/mongodb/mongodb_test.go
@@ -54,20 +54,5 @@ var _ = Describe("MongoDB", func() {
 		By("getting the document using the second app")
 		got := appTwo.GET("%s/%s/%s", databaseName, collectionName, documentName)
 		Expect(got).To(Equal(documentData))
-
-		By("updating the instance plan")
-		serviceInstance.UpdateService("-p", "large")
-
-		By("checking that the created database is still present")
-		databases = appOne.GET("")
-		Expect(databases).To(MatchJSON(fmt.Sprintf(`["%s"]`, databaseName)))
-
-		By("checking that the created collection is still present")
-		collections = appOne.GET(databaseName)
-		Expect(collections).To(MatchJSON(fmt.Sprintf(`["%s"]`, collectionName)))
-
-		By("checking previous data still accessible")
-		got = appTwo.GET("%s/%s/%s", databaseName, collectionName, documentName)
-		Expect(got).To(Equal(documentData))
 	})
 })

--- a/acceptance-tests/mssql-server-pair/mssql_server_pair_and_fog_db_test.go
+++ b/acceptance-tests/mssql-server-pair/mssql_server_pair_and_fog_db_test.go
@@ -1,4 +1,4 @@
-package mssql_server_test
+package mssql_server_pair_test
 
 import (
 	"acceptancetests/helpers"

--- a/acceptance-tests/mssql-server-pair/mssql_server_suite_test.go
+++ b/acceptance-tests/mssql-server-pair/mssql_server_suite_test.go
@@ -1,0 +1,46 @@
+package mssql_server_pair_test
+
+import (
+	"os"
+	"testing"
+
+	"code.cloudfoundry.org/jsonry"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMssqlServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MssqlServer Suite")
+}
+
+var metadata struct {
+	ResourceGroup             string `jsonry:"name"`
+	PreProvisionedSQLUsername string `jsonry:"masb_config.pre_provisioned_sql.username"`
+	PreProvisionedSQLPassword string `jsonry:"masb_config.pre_provisioned_sql.password"`
+	PreProvisionedSQLServer   string `jsonry:"masb_config.pre_provisioned_sql.server_name"`
+	PreProvisionedSQLLocation string `jsonry:"masb_config.location"`
+	PreProvisionedFOGUsername string `jsonry:"masb_config.pre_provisioned_fog_sql.username"`
+	PreProvisionedFOGPassword string `jsonry:"masb_config.pre_provisioned_fog_sql.password"`
+	PreProvisionedFOGServer   string `jsonry:"masb_config.pre_provisioned_fog_sql.server_name"`
+	PreProvisionedFOGLocation string `jsonry:"masb_config.pre_provisioned_fog_sql.location"`
+}
+
+var _ = BeforeSuite(func() {
+	file := os.Getenv("ENVIRONMENT_LOCK_METADATA")
+	Expect(file).NotTo(BeEmpty(), "You must set the ENVIRONMENT_LOCK_METADATA environment variable")
+
+	contents, err := os.ReadFile(file)
+	Expect(err).NotTo(HaveOccurred())
+
+	Expect(jsonry.Unmarshal(contents, &metadata)).NotTo(HaveOccurred())
+	Expect(metadata.ResourceGroup).NotTo(BeEmpty())
+	Expect(metadata.PreProvisionedSQLUsername).NotTo(BeEmpty())
+	Expect(metadata.PreProvisionedSQLPassword).NotTo(BeEmpty())
+	Expect(metadata.PreProvisionedSQLServer).NotTo(BeEmpty())
+	Expect(metadata.PreProvisionedSQLLocation).NotTo(BeEmpty())
+	Expect(metadata.PreProvisionedFOGUsername).NotTo(BeEmpty())
+	Expect(metadata.PreProvisionedFOGPassword).NotTo(BeEmpty())
+	Expect(metadata.PreProvisionedFOGServer).NotTo(BeEmpty())
+	Expect(metadata.PreProvisionedFOGLocation).NotTo(BeEmpty())
+})


### PR DESCRIPTION
- MongoDB test was taking 54 mins and mssql-server 34 mins
- splits the mssql-server tests into separate directories so that it's
easier to run the two tests in parallel.
- removes the plan change from MongoDB. This was useful for seeing that
a bug had been fixed, but it's too slow for a forever test.
- longest running test is now Redis at 32 mins, but there are no easy
improvements for that one

[#180197227](https://www.pivotaltracker.com/story/show/180197227)