### PR TITLE
test: mssql upgrade test checks data retention after unbind/bind

### DIFF
--- a/acceptance-tests/apps/mssqlapp/internal/app/create_schema.go
+++ b/acceptance-tests/apps/mssqlapp/internal/app/create_schema.go
@@ -19,7 +19,7 @@ func handleCreateSchema(config string) func(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
-		_, err = db.Exec(fmt.Sprintf(`CREATE SCHEMA %s`, schema))
+		_, err = db.Exec(fmt.Sprintf(`CREATE SCHEMA %s AUTHORIZATION dbo`, schema))
 		if err != nil {
 			log.Printf("Error creating schema: %s", err)
 			http.Error(w, "Failed to create schema.", http.StatusBadRequest)

--- a/acceptance-tests/upgrade/update_and_upgrade_mssql_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mssql_test.go
@@ -58,9 +58,6 @@ var _ = Describe("UpgradeMssqlTest", func() {
 			got = appTwo.GET("%s/%s", schema, keyOne)
 			Expect(got).To(Equal(valueOne))
 
-			By("dropping the schema used to allow us to unbind")
-			appOne.DELETE(schema)
-
 			By("deleting bindings created before the upgrade")
 			serviceInstance.Unbind(appOne)
 			serviceInstance.Unbind(appTwo)
@@ -70,20 +67,21 @@ var _ = Describe("UpgradeMssqlTest", func() {
 			serviceInstance.Bind(appTwo)
 			apps.Restage(appOne, appTwo)
 
+			By("checking previously written data still accessible")
+			got = appTwo.GET("%s/%s", schema, keyOne)
+			Expect(got).To(Equal(valueOne))
+
 			By("creating a schema using the first app")
-			schema = random.Name(random.WithMaxLength(10))
-			appOne.PUT("", schema)
+			schemaTwo := random.Name(random.WithMaxLength(10))
+			appOne.PUT("", schemaTwo)
 
 			By("checking data can still be written and read")
-			keyThree := random.Hexadecimal()
-			valueThree := random.Hexadecimal()
-			appOne.PUT(valueThree, "%s/%s", schema, keyThree)
+			keyTwo := random.Hexadecimal()
+			valueTwo := random.Hexadecimal()
+			appOne.PUT(valueTwo, "%s/%s", schemaTwo, keyTwo)
 
-			got = appTwo.GET("%s/%s", schema, keyThree)
-			Expect(got).To(Equal(valueThree))
-
-			By("dropping the schema used to allow us to unbind")
-			appOne.DELETE(schema)
+			got = appTwo.GET("%s/%s", schemaTwo, keyTwo)
+			Expect(got).To(Equal(valueTwo))
 		})
 	})
 })


### PR DESCRIPTION
- as part of the fix in [180314427](https://www.pivotaltracker.com/story/show/180314427) we
  can now check that data persists after unbinding/rebinding to a mssql service.

[#180330326](https://www.pivotaltracker.com/story/show/180330326)