### PR TITLE
test(mongodb): use smaller plans

### DIFF
--- a/acceptance-tests/mongodb/mongodb_test.go
+++ b/acceptance-tests/mongodb/mongodb_test.go
@@ -16,7 +16,7 @@ var _ = Describe("MongoDB", func() {
 		By("creating a service instance")
 		databaseName := random.Name(random.WithPrefix("database"))
 		collectionName := random.Name(random.WithPrefix("collection"))
-		serviceInstance := helpers.CreateServiceFromBroker("csb-azure-mongodb", "medium", helpers.DefaultBroker().Name, map[string]interface{}{
+		serviceInstance := helpers.CreateServiceFromBroker("csb-azure-mongodb", "small", helpers.DefaultBroker().Name, map[string]interface{}{
 			"db_name":         databaseName,
 			"collection_name": collectionName,
 			"shard_key":       "_id",

--- a/acceptance-tests/upgrade/update_and_upgrade_mongodb_test.go
+++ b/acceptance-tests/upgrade/update_and_upgrade_mongodb_test.go
@@ -23,7 +23,7 @@ var _ = Describe("UpgradeMongoTest", func() {
 			By("creating a service instance")
 			databaseName := random.Name(random.WithPrefix("database"))
 			collectionName := random.Name(random.WithPrefix("collection"))
-			serviceInstance := helpers.CreateServiceFromBroker("csb-azure-mongodb", "medium", serviceBroker.Name, map[string]interface{}{
+			serviceInstance := helpers.CreateServiceFromBroker("csb-azure-mongodb", "small", serviceBroker.Name, map[string]interface{}{
 				"db_name":         databaseName,
 				"collection_name": collectionName,
 				"shard_key":       "_id",
@@ -55,7 +55,7 @@ var _ = Describe("UpgradeMongoTest", func() {
 			serviceBroker.Update(developmentBuildDir)
 
 			By("updating the instance plan")
-			serviceInstance.UpdateService("-p", "large")
+			serviceInstance.UpdateService("-p", "medium")
 
 			By("checking previous data still accessible")
 			got = appTwo.GET("%s/%s/%s", databaseName, collectionName, documentNameOne)


### PR DESCRIPTION
The test was updated to use medium->large plan change to rule out a
potential issue with the small plan. But we now now that the
small->medium plan change works just as well, so we should use that as
the main test since it may be faster and use less resources.

[#180197227](https://www.pivotaltracker.com/story/show/180197227)